### PR TITLE
Use the latest NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - '6'
-  - '4'
 cache:
   directories:
     - node_modules
 before_install:
-  - npm install -g npm
   - npm prune
   - npm update
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   directories:
     - node_modules
 before_install:
+  - npm install -g npm
   - npm prune
   - npm update
 deploy:


### PR DESCRIPTION
Looking at a recent Travis CI job:

```bash
npm WARN engine postcss-load-config@1.0.0: wanted: {"node":">=0.12","npm":">=3"} (current: {"node":"4.6.2","npm":"2.15.11"})
npm WARN engine postcss-load-plugins@2.0.0: wanted: {"node":">=0.12","npm":">=3"} (current: {"node":"4.6.2","npm":"2.15.11"})
npm WARN engine postcss-load-options@1.0.2: wanted: {"node":">=0.12","npm":">=3"} (current: {"node":"4.6.2","npm":"2.15.11"})
```

Adding `npm install -g npm` will install NPM 3.x, soon 4.x but will/should satisfy the above requirements.

See also https://github.com/postcss/postcss-loader/pull/140