### PR TITLE
chore: Use Node.js 7.5.0 for Travis CI per package.json requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6'
+- '7.5.0'
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
Fixes #55 