### PR TITLE
Replace ESLint rule: `node/no-unsupported-features` -> `node/no-unsupported-features/es-syntax`

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
       "sourceType": "module"
     },
     "rules": {
-      "node/no-unsupported-features": [
+      "node/no-unsupported-features/es-syntax": [
         "error",
         {
           "ignores": [


### PR DESCRIPTION
Fix failed `npm run lint:js` command.

See also detail discussion on https://github.com/stylelint/stylelint-demo/issues/110#issuecomment-420648771