### PR TITLE
Update eslint-config-stylelint to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "eslint": "^5.0.0",
-    "eslint-config-stylelint": "^8.0.0",
+    "eslint-config-stylelint": "^8.2.0",
     "eslint-plugin-react": "^7.0.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
       "sourceType": "module"
     },
     "rules": {
-      "node/no-unsupported-features": [
+      "node/no-unsupported-features/es-syntax": [
         "error",
         {
           "ignores": [


### PR DESCRIPTION
Also, this PR replaces deprecated `eslint-plugin-node` rule.

- `node/no-unsupported-features` -> `node/no-unsupported-features/es-syntax`
- https://github.com/mysticatea/eslint-plugin-node/blob/v7.0.1/docs/rules/no-unsupported-features.md
- https://github.com/mysticatea/eslint-plugin-node/blob/v7.0.1/docs/rules/no-unsupported-features/es-syntax.md

Because `eslint-config-stylelint@8.2.0` upgraded `eslint-plugin-node` from `^5.2.1` to `^7.0.0`.
For details, please see <https://github.com/stylelint/eslint-config-stylelint/compare/8.1.0...8.2.0>.


Fixes #110 