### PR TITLE
Update dependencies to Babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest": "npm run lint",
     "test": "npm run tape",
     "posttest": "npm run bundle",
-    "tape": "tape --require babel-core/register \"src/**/__tests__/**/*.js\"",
+    "tape": "tape --require @babel/register \"src/**/__tests__/**/*.js\"",
     "prebundle": "rimraf dist",
     "bundle": "NODE_ENV=production webpack --config webpack.config.prod.js",
     "heroku-postbuild": "npm run bundle",
@@ -23,16 +23,14 @@
     "start:dev": "NODE_ENV=development nodemon --ignore src/common/ index.js"
   },
   "dependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "autoprefixer": "^9.1.5",
-    "babel-cli": "^6.10.1",
-    "babel-core": "^6.10.4",
-    "babel-eslint": "^8.0.0",
-    "babel-loader": "^7.0.0",
-    "babel-plugin-webpack-loaders": "^0.9.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.11.1",
-    "babel-preset-react-hmre": "^1.1.1",
-    "babel-preset-stage-2": "^6.11.0",
+    "babel-eslint": "^10.0.0",
+    "babel-loader": "^8.0.0",
     "body-parser": "^1.15.2",
     "brace": "^0.11.0",
     "classnames": "^2.2.5",
@@ -76,11 +74,13 @@
   "engines": {
     "node": "10"
   },
+  "browserslist": [
+    "defaults"
+  ],
   "babel": {
     "presets": [
-      "es2015",
-      "stage-2",
-      "react"
+      "@babel/preset-env",
+      "@babel/preset-react"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
### Migration steps

1. Use the tool [`babel-upgrade`](https://github.com/babel/babel-upgrade).

    ```sh
    npx babel-upgrade --write
    ```

2. Install `@babel/register` package to avoid test error.

3. Remove `@babel/plugin-*` packages added by `babel-upgrade`.

4. Remove unused `babel-preset-react-hmre` package.

5. Remove unused `babel-plugin-webpack-loaders` package.

6. Add [`browserslist`](https://github.com/browserslist/browserslist) entry to `package.json`, which is used by [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env).

7. Update [`babel-eslint`](https://github.com/babel/babel-eslint) to latest version.

For details, please see [the migration guide](https://babeljs.io/docs/en/v7-migration).

Close #120 