### PR TITLE
Fix /lint spam regression after #141

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "css-loader": "^2.0.0",
     "express": "^4.16.4",
     "html-webpack-plugin": "^3.2.0",
-    "lodash.debounce": "^4.0.8",
     "morgan": "^1.9.1",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.1.2",
@@ -50,6 +49,7 @@
     "stylelint": "^9.10.1",
     "stylelint-config-recommended": "^2.1.0",
     "stylelint-config-standard": "^18.2.0",
+    "use-debounce": "0.0.9",
     "webpack": "^4.21.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/src/common/root/index.js
+++ b/src/common/root/index.js
@@ -4,7 +4,7 @@ import Linter from "../linter";
 import recommendedConfig from "stylelint-config-recommended";
 import standardConfig from "stylelint-config-standard";
 import "whatwg-fetch";
-import useDebouncedCallback from "use-debounce/lib/callback";
+import { useDebouncedCallback } from "use-debounce";
 
 const defaultCSS = "a {color: #FFF; }\n";
 const defaultConfig = {

--- a/src/common/root/index.js
+++ b/src/common/root/index.js
@@ -1,10 +1,10 @@
 /* global fetch:false */
 import React, { useState, useEffect } from "react";
-import debounce from "lodash.debounce";
 import Linter from "../linter";
 import recommendedConfig from "stylelint-config-recommended";
 import standardConfig from "stylelint-config-standard";
 import "whatwg-fetch";
+import useDebouncedCallback from "use-debounce/lib/callback";
 
 const defaultCSS = "a {color: #FFF; }\n";
 const defaultConfig = {
@@ -47,9 +47,13 @@ export default function Root() {
       });
   }
 
+  const debouncedLint = useDebouncedCallback(() => {
+    lint();
+  }, 250);
+
   useEffect(() => {
-    debounce(lint, 250)();
-  });
+    debouncedLint();
+  }, [code, config, syntax]);
 
   return (
     <Linter


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I accidentally introduced a regression in #141. Demo calls `/lint` endpoint every 250ms all the time after loading. 
