### PR TITLE
Replace Ace with react-simple-code-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.4",
     "body-parser": "^1.18.3",
-    "brace": "^0.11.1",
     "classnames": "^2.2.6",
     "compression": "^1.7.3",
     "css-loader": "^2.0.0",
@@ -37,10 +36,11 @@
     "morgan": "^1.9.1",
     "postcss-loader": "^3.0.0",
     "postcss-preset-env": "^6.1.2",
+    "prismjs": "^1.15.0",
     "react": "^16.8.1",
-    "react-ace": "^6.2.0",
     "react-css-modules": "^4.7.7",
     "react-dom": "^16.8.1",
+    "react-simple-code-editor": "^0.9.0",
     "rimraf": "^2.6.2",
     "serve-favicon": "^2.5.0",
     "style-loader": "^0.23.1",
@@ -137,7 +137,6 @@
         "media"
       ],
       "color-named": "always-where-possible",
-      "color-no-hex": true,
       "custom-media-pattern": "^([a-z]+-?)*([a-z]+)$",
       "custom-property-pattern": "^([a-z]+-?)*([a-z]+)$",
       "declaration-block-no-duplicate-properties": true,
@@ -145,7 +144,9 @@
       "font-weight-notation": "numeric",
       "function-url-quotes": "always",
       "function-whitelist": [
-        "color"
+        "color",
+        "counter",
+        "hsla"
       ],
       "media-feature-name-no-vendor-prefix": true,
       "no-descending-specificity": true,
@@ -171,7 +172,16 @@
       "selector-no-vendor-prefix": true,
       "selector-pseudo-class-whitelist": [
         "hover",
-        "focus"
+        "focus",
+        "global"
+      ],
+      "selector-pseudo-class-no-unknown": [
+        true,
+        {
+          "ignorePseudoClasses": [
+            "global"
+          ]
+        }
       ],
       "string-quotes": "double",
       "unit-whitelist": [

--- a/src/common/linter/index.css
+++ b/src/common/linter/index.css
@@ -76,3 +76,90 @@
     width: 50%;
   }
 }
+
+.editorWrapper {
+  border-left: 55px solid #e8e8e8;
+  font: 12px/normal Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
+}
+
+.editor {
+  counter-reset: line;
+  min-height: 240px;
+}
+
+.editorLineNumber::before {
+  color: #aaa;
+  content: counter(line);
+  counter-increment: line;
+  margin-right: 13px;
+  position: absolute;
+  right: 100%;
+  text-align: right;
+  user-select: none;
+}
+
+/* stylelint-disable selector-class-pattern */
+:global .token.comment,
+:global .token.prolog,
+:global .token.doctype,
+:global .token.cdata {
+  color: slategray;
+}
+
+:global .token.punctuation {
+  color: #999;
+}
+
+:global .namespace {
+  opacity: 0.7;
+}
+
+:global .token.property,
+:global .token.tag,
+:global .token.boolean,
+:global .token.number,
+:global .token.constant,
+:global .token.symbol,
+:global .token.deleted {
+  color: #905;
+}
+
+:global .token.selector,
+:global .token.attr-name,
+:global .token.string,
+:global .token.char,
+:global .token.builtin,
+:global .token.inserted {
+  color: #690;
+}
+
+:global .token.operator,
+:global .token.entity,
+:global .token.url,
+:global .language-css .token.string,
+:global .style .token.string {
+  background: hsla(0, 0%, 100%, 0.5);
+  color: #9a6e3a;
+}
+
+:global .token.atrule,
+:global .token.attr-value,
+:global .token.keyword {
+  color: #07a;
+}
+
+:global .token.function,
+:global .token.class-name {
+  color: #dd4a68;
+}
+
+:global .token.regex,
+:global .token.important,
+:global .token.variable {
+  color: #e90;
+}
+
+:global .language-json .token.number,
+:global .language-json .token.boolean {
+  color: #25b;
+}

--- a/src/common/linter/index.js
+++ b/src/common/linter/index.js
@@ -1,16 +1,21 @@
-import PropTypes from "prop-types";
 import React from "react";
+import PropTypes from "prop-types";
+import Editor from "react-simple-code-editor";
+import { highlight, languages } from "prismjs/components/prism-core";
+import "prismjs/components/prism-css";
+import "prismjs/components/prism-json";
+
 import WarningList from "../warning-list/";
 import SyntaxSelect from "../syntax-select";
-import brace from "brace"; // eslint-disable-line no-unused-vars
-import AceEditor from "react-ace";
-
-import "brace/mode/json";
-import "brace/mode/css";
-import "brace/theme/github";
-import "brace/ext/language_tools";
 
 import styles from "./index.css";
+
+function hightlightWithLineNumbers(input, language) {
+  return highlight(input, language)
+    .split("\n")
+    .map(line => `<span class=${styles.editorLineNumber}></span>${line}`)
+    .join("\n");
+}
 
 const Linter = ({
   onCodeChange,
@@ -42,29 +47,15 @@ const Linter = ({
           {"input"}
         </span>
 
-        <AceEditor
-          mode="css"
-          theme="github"
-          name="code"
-          tabSize={2}
-          value={code}
-          height="100%"
-          width="100%"
-          maxLines={Infinity}
-          minLines={15}
-          showPrintMargin={false}
-          onChange={onCodeChange}
-          onLoad={editor => {
-            editor.focus();
-            // disable Ace's built in syntax checking
-            editor.getSession().setUseWorker(false);
-          }}
-          editorProps={{
-            $blockScrolling: true,
-            enableBasicAutocompletion: true,
-            enableLiveAutocompletion: true
-          }}
-        />
+        <div className={styles.editorWrapper}>
+          <Editor
+            value={code}
+            onValueChange={onCodeChange}
+            highlight={input => hightlightWithLineNumbers(input, languages.css)}
+            className={styles.editor}
+            padding={10}
+          />
+        </div>
       </div>
 
       <div className={styles.output}>
@@ -76,20 +67,17 @@ const Linter = ({
       <div className={styles.configInput}>
         <span className={styles.caption}>{"Config input"}</span>
 
-        <AceEditor
-          mode="json"
-          theme="github"
-          name="config"
-          tabSize={2}
-          value={config}
-          height="100%"
-          width="100%"
-          maxLines={Infinity}
-          minLines={5}
-          showPrintMargin={false}
-          onChange={onConfigChange}
-          editorProps={{ $blockScrolling: true }}
-        />
+        <div className={styles.editorWrapper}>
+          <Editor
+            value={config}
+            onValueChange={onConfigChange}
+            highlight={input =>
+              hightlightWithLineNumbers(input, languages.json)
+            }
+            className={`${styles.editor} language-json`}
+            padding={10}
+          />
+        </div>
       </div>
     </div>
   );

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -41,11 +41,5 @@ module.exports = {
       template: "src/client/index.ejs"
     }),
     new webpack.EnvironmentPlugin("NODE_ENV")
-  ],
-  resolve: {
-    alias: {
-      // Prevent a second copy being bundled as part of react-ace
-      brace: path.resolve("./node_modules/brace")
-    }
-  }
+  ]
 };


### PR DESCRIPTION
We're using Ace as a code editor for the demo. It's a huuuge. Also, syntax highlighting almost non-existent.

I've replaced Ace with [react-simple-code-editor](https://github.com/satya164/react-simple-code-editor) and [Prism](https://prismjs.com/) for syntax hightlighting. [React Styleguidist](https://github.com/styleguidist/react-styleguidist) is using this combination and it's a popular project.

Two big improvements with new libraries:

1. Bundle size reduced **five** times! From 835KB to 163KB.
2. Syntax highlighting is so much better. I used the default Prism theme (with some tweaking for better JSON highlighting).

<img width="1352" alt="screenshot 2019-02-17 at 04 37 17" src="https://user-images.githubusercontent.com/654597/52908048-c043be80-326d-11e9-9c02-e085851a05e3.png">
