### PR TITLE
Pin react-simple-code-editor to show line numbers

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,10 @@
+# https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"
+    ignored_updates:
+      - match:
+          dependency_name: "react-simple-code-editor"
+    version_requirement_updates: "widen_ranges"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9296,9 +9296,9 @@
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "react-simple-code-editor": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz",
-      "integrity": "sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.9.1.tgz",
+      "integrity": "sha512-iHwgmAAB5WUiKdR2yyBClGpfbaqRvaO6/EEQ4r1w5GB6LcO9qmmcRe56xymUCgZLt3CUBCKOLkdf2TBdvdo/Zw=="
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^16.9.0",
     "react-css-modules": "^4.7.11",
     "react-dom": "^16.9.0",
-    "react-simple-code-editor": "0.10.0",
+    "react-simple-code-editor": "0.9.1",
     "rimraf": "^3.0.0",
     "serve-favicon": "^2.5.0",
     "style-loader": "^1.0.0",


### PR DESCRIPTION
Pin [back](https://github.com/stylelint/stylelint-demo/pull/169) `react-simple-code-editor` to show line numbers. It was accidentally [updated](https://github.com/stylelint/stylelint-demo/pull/186) recently.
