### PR TITLE
Use more sane tab-size for editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 *.log
+.stylelintcache

--- a/src/common/linter/index.css
+++ b/src/common/linter/index.css
@@ -85,6 +85,7 @@
 .editor {
   counter-reset: line;
   min-height: 240px;
+  tab-size: 4;
 }
 
 /* stylelint-disable-next-line selector-max-type */


### PR DESCRIPTION
Default size for a tab character is 8 spaces wide, which is too big. 4 spaces wide looks like a nice compromise between too big and too small like 2 spaces.

Before:

![](https://user-images.githubusercontent.com/654597/94852690-8fa49e80-042a-11eb-8619-ebdb7c82bc14.png)

After:

![](https://user-images.githubusercontent.com/654597/94852732-9a5f3380-042a-11eb-89a7-49c2f1f81f47.png)
