### PR TITLE
Simplify CI configuration for Actions and update Node.js from v10 to v12

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,60 +9,15 @@ on:
     branches:
       - '**'
 
-env:
-  CI: true
-
 jobs:
-  lint:
-    name: Lint on Node.js ${{ matrix.node }} and ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        node: [12]
-        os: [ubuntu-latest]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install latest npm
-        run: npm install --global npm@latest
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
   test:
-    name: Test on Node.js ${{ matrix.node }}
-
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [10, 12]
-
     steps:
       - uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install latest npm
-        run: npm install --global npm@latest
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Test
-        run: npm test
+          node-version: '10'
+      - run: npm install --global npm@latest
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '12'
       - name: Install latest npm
         run: npm install --global npm@latest
       - name: Install dependencies

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,13 +11,20 @@ on:
 
 jobs:
   test:
+    name: Lint and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
         with:
           node-version: '10'
-      - run: npm install --global npm@latest
-      - run: npm ci
-      - run: npm run lint
-      - run: npm test
+      - name: Install latest npm
+        run: npm install --global npm@latest
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup node
+      - name: Set up node
         uses: actions/setup-node@v2
         with:
           node-version: '12'

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "postcss": {
     "map": true,


### PR DESCRIPTION
- Remove matrix. This project is *not* a library, so I think the matrix is needless.
- Unify `lint` and `test` jobs to one job for simplicity.
- Remove needless `CI: true` because it is set by default.
  See <https://docs.github.com/en/actions/reference/environment-variables>.
- Bump actions/setup-node from v1 to v2.
  See <https://github.com/actions/setup-node>.

Also,

- Update Node.js from v10 to v12. See <https://github.com/stylelint/stylelint-demo/pull/245#discussion_r589272158>.

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
