### PR TITLE
Fix compat with docusaurus 2

### DIFF
--- a/src/common/linter/index.css
+++ b/src/common/linter/index.css
@@ -1,4 +1,5 @@
 .root {
+  background: white;
   display: flex;
   flex-direction: column;
 }

--- a/src/common/warning-list/index.css
+++ b/src/common/warning-list/index.css
@@ -11,6 +11,6 @@
 }
 
 .success {
-  color: limegreen;
+  color: green;
   line-height: 16px;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint.io/pull/174

> Is there anything in the PR that needs further explanation?

It's a quick compatibility fix. Setting the background colour on the linter root stops the dark mode of docusaurus 2 bleeding through.

Can be merged as works with both docusaurus 1 and 2.
