### PR TITLE
Add stylelint-order and turn on new rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.4",
         "remark-cli": "^11.0.0",
+        "stylelint-order": "^6.0.2",
         "supertest": "^6.3.3",
         "webpack-cli": "^5.0.1",
         "webpack-dev-middleware": "^6.0.1",
@@ -11545,6 +11546,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-sorting": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.1.tgz",
+      "integrity": "sha512-go9Zoxx7KQH+uLrJ9xa5wRErFeXu01ydA6O8m7koPXkmAN7Ts//eRcIqjo0stBR4+Nir2gMYDOWAOx7O5EPUZA==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.4.20"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -13578,6 +13588,19 @@
       },
       "peerDependencies": {
         "stylelint": "^15.0.0"
+      }
+    },
+    "node_modules/stylelint-order": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.2.tgz",
+      "integrity": "sha512-yuac0BE6toHd27wUPvYVVQicAJthKFIv1HPQFH3Q0dExiO3Z6Uam7geoO0tUd5Z9ddsATYK++1qWNDX4RxMH5Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^8.4.21",
+        "postcss-sorting": "^8.0.1"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/stylelint/node_modules/balanced-match": {
@@ -23526,6 +23549,13 @@
         "util-deprecate": "^1.0.2"
       }
     },
+    "postcss-sorting": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.1.tgz",
+      "integrity": "sha512-go9Zoxx7KQH+uLrJ9xa5wRErFeXu01ydA6O8m7koPXkmAN7Ts//eRcIqjo0stBR4+Nir2gMYDOWAOx7O5EPUZA==",
+      "dev": true,
+      "requires": {}
+    },
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -25133,6 +25163,16 @@
       "integrity": "sha512-NbeHOmpRQhjZh5XB1B/S4MLRWvz4xxAxeDBjzl0tY2xEcayNhLbaRGF0ZQzq+DQZLCcPpOHeS2Ru1ydbkhkmLg==",
       "requires": {
         "stylelint-config-recommended": "^10.0.1"
+      }
+    },
+    "stylelint-order": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.2.tgz",
+      "integrity": "sha512-yuac0BE6toHd27wUPvYVVQicAJthKFIv1HPQFH3Q0dExiO3Z6Uam7geoO0tUd5Z9ddsATYK++1qWNDX4RxMH5Q==",
+      "dev": true,
+      "requires": {
+        "postcss": "^8.4.21",
+        "postcss-sorting": "^8.0.1"
       }
     },
     "sugarss": {

--- a/package.json
+++ b/package.json
@@ -80,13 +80,19 @@
     ]
   },
   "stylelint": {
-    "extends": "stylelint-config-standard",
+    "extends": [
+      "stylelint-config-standard"
+    ],
+    "plugins": [
+      "stylelint-order"
+    ],
     "rules": {
       "at-rule-allowed-list": [
         "import",
         "media"
       ],
       "color-named": "always-where-possible",
+      "declaration-property-value-no-unknown": true,
       "font-weight-notation": "numeric",
       "function-allowed-list": [
         "color",
@@ -94,6 +100,23 @@
         "hsl",
         "linear-gradient",
         "var"
+      ],
+      "order/order": [
+        [
+          "custom-properties",
+          "declarations",
+          "rules",
+          "at-rules"
+        ],
+        {
+          "severity": "warning"
+        }
+      ],
+      "order/properties-alphabetical-order": [
+        true,
+        {
+          "severity": "warning"
+        }
       ],
       "property-no-unknown": [
         true,
@@ -179,6 +202,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
     "remark-cli": "^11.0.0",
+    "stylelint-order": "^6.0.2",
     "supertest": "^6.3.3",
     "webpack-cli": "^5.0.1",
     "webpack-dev-middleware": "^6.0.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it reverses a change made during the release process.

> Is there anything in the PR that needs further explanation?

The order plugin now has `15.0.0` as a peer dep.
