### PR TITLE
Fix alignment of installed deps

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -55,8 +55,24 @@
 	border-radius: 2px;
 }
 
+.sd-deps {
+	display: grid;
+	grid:
+		'deps-label deps-label'
+		'deps-monaco deps-installed'
+		/ 1fr 1fr;
+}
+
+.sd-deps > label {
+	grid-area: deps-label;
+}
+
+.sd-deps-monaco {
+	grid-area: deps-monaco;
+}
+
 .sd-deps-installed {
-	padding-block: 0.75rem;
+	grid-area: deps-installed;
 	padding-inline: 0.5rem;
 }
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Moves installed deps alongside the package.json content to align and be more consistent with the `code` tab.

<img width="1198" alt="Screenshot 2023-03-05 at 08 29 29" src="https://user-images.githubusercontent.com/808227/222950179-b5b48252-a0fd-4319-9730-b2efc73818a4.png">

