### PR TITLE
Add `:has()` polyfill for Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^18.15.11",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
+        "css-has-pseudo": "^5.0.2",
         "eslint": "^8.38.0",
         "eslint-config-stylelint": "^18.0.0",
         "husky": "^8.0.3",
@@ -1597,6 +1598,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/css-has-pseudo": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-5.0.2.tgz",
+      "integrity": "sha512-q+U+4QdwwB7T9VEW/LyO6CFrLAeLqOykC5mDqJXc7aKZAhDbq7BvGT13VGJe+IwBfdN2o3Xdw2kJ5IxwV1Sc9Q==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/selector-specificity": "^2.0.1",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/css-tree": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
+    "css-has-pseudo": "^5.0.2",
     "eslint": "^8.38.0",
     "eslint-config-stylelint": "^18.0.0",
     "husky": "^8.0.3",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+// TODO: This polyfill will be no longer needed when Firefox supports `:has()`. See https://caniuse.com/css-has
+import postcssHasPseudo from 'css-has-pseudo';
+
+export default {
+	plugins: [postcssHasPseudo()],
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import './style.css';
+import './polyfills';
 import { compress, decompress } from './utils/compress';
 import type { ConfigFormat } from './components/config-editor';
 import { debounce } from './utils/debounce';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,3 +1,4 @@
 // TODO: This polyfill will be no longer needed when Firefox supports `:has()`. See https://caniuse.com/css-has
+// @ts-expect-error -- TS2307: Cannot find module 'css-has-pseudo/browser' or its corresponding type declarations.
 import cssHasPseudo from 'css-has-pseudo/browser';
 cssHasPseudo(document);

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,3 @@
+// TODO: This polyfill will be no longer needed when Firefox supports `:has()`. See https://caniuse.com/css-has
+import cssHasPseudo from 'css-has-pseudo/browser';
+cssHasPseudo(document);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #355

> Is there anything in the PR that needs further explanation?

This change installs the `css-has-pseudo` PostCSS plugin, including a JS polyfill.
See https://github.com/csstools/postcss-plugins/tree/main/plugins/css-has-pseudo


[`:has()` on caniuse.com](https://caniuse.com/css-has)

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/473530/233817285-a084a6f9-19f5-4a3d-9a93-8f42bcf3afd0.png">

