### PR TITLE
Show message on no problems

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -109,6 +109,10 @@
 	margin-block: 0;
 }
 
+.sd-warnings:empty::before {
+	content: '✅ No problems!';
+}
+
 .sd-warning-item {
 	display: flex;
 	gap: 0.5rem;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I think showing a message is more helpful than no output when there are no lint problems.

<img width="132" alt="Screenshot 2023-04-26 at 22 57 35" src="https://user-images.githubusercontent.com/473530/234598834-1a165fe1-a4a6-4f38-a1de-2ba2a7d5ab8c.png">
