### PR TITLE
Uninstall `rimraf` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.8",
         "remark-cli": "^11.0.0",
-        "rimraf": "^5.0.1",
         "stylelint": "^15.10.1",
         "stylelint-config-standard": "^33.0.0",
         "stylelint-order": "^6.0.3",
@@ -6621,24 +6620,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
-      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^10.2.5"
-      },
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rollup": {
       "version": "3.23.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "node -e \"fs.rmSync('dist', {force: true, recursive: true})\"",
     "build": "vite build",
     "build:lib": "vite build -c vite.config.lib.ts",
     "dev": "vite",
@@ -163,7 +163,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
     "remark-cli": "^11.0.0",
-    "rimraf": "^5.0.1",
     "stylelint": "^15.10.1",
     "stylelint-config-standard": "^33.0.0",
     "stylelint-order": "^6.0.3",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`fs.rmSync()` is available on Node.js 18 instead.
See https://nodejs.org/api/fs.html#fsrmsyncpath-options
