### PR TITLE
Use Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     labels:
       - 'pr: dependencies'
+    groups:
+      development-dependencies:
+        dependency-type: 'development'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@webcontainer/api": "^1.1.5",
         "ansi-regex": "^6.0.1",
-        "lz-string": "^1.5.0"
+        "lz-string": "^1.5.0",
+        "monaco-editor": "^0.40.0"
       },
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
@@ -26,7 +27,6 @@
         "eslint-config-stylelint": "^19.1.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
-        "monaco-editor": "^0.40.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.1",
         "remark-cli": "^11.0.0",
@@ -4872,8 +4872,7 @@
     "node_modules/monaco-editor": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.40.0.tgz",
-      "integrity": "sha512-1wymccLEuFSMBvCk/jT1YDW/GuxMLYwnFwF9CDyYCxoTw2Pt379J3FUhwy9c43j51JdcxVPjwk0jm0EVDsBS2g==",
-      "dev": true
+      "integrity": "sha512-1wymccLEuFSMBvCk/jT1YDW/GuxMLYwnFwF9CDyYCxoTw2Pt379J3FUhwy9c43j51JdcxVPjwk0jm0EVDsBS2g=="
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
   "dependencies": {
     "@webcontainer/api": "^1.1.5",
     "ansi-regex": "^6.0.1",
-    "lz-string": "^1.5.0"
+    "lz-string": "^1.5.0",
+    "monaco-editor": "^0.40.0"
   },
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
@@ -158,7 +159,6 @@
     "eslint-config-stylelint": "^19.1.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
-    "monaco-editor": "^0.40.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.1",
     "remark-cli": "^11.0.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint.io/pull/341

> Is there anything in the PR that needs further explanation?

This change makes Dependabot Pull Requests more efficient by grouping relevant dependencies' updates.

Also, this moves `monaco-editor` from `devDependencies` to `dependencies` since it's a runtime dependency.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
