### PR TITLE
Use xterm for console display area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@webcontainer/api": "^1.1.7",
         "ansi-regex": "^6.0.1",
         "lz-string": "^1.5.0",
-        "monaco-editor": "^0.43.0"
+        "monaco-editor": "^0.43.0",
+        "xterm": "^5.3.0",
+        "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
@@ -9225,6 +9227,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg=="
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,9 @@
     "@webcontainer/api": "^1.1.7",
     "ansi-regex": "^6.0.1",
     "lz-string": "^1.5.0",
-    "monaco-editor": "^0.43.0"
+    "monaco-editor": "^0.43.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",

--- a/src/demo.css
+++ b/src/demo.css
@@ -58,8 +58,8 @@
 .sd-deps {
 	display: grid;
 	grid:
-		'deps-label deps-label'
-		'deps-monaco deps-installed'
+		'deps-label deps-label' min-content
+		'deps-monaco deps-installed' 1fr
 		/ 1fr 1fr;
 }
 
@@ -98,7 +98,6 @@
 	overflow: auto;
 	padding-block: 0.75rem;
 	padding-inline: 0.5rem;
-	white-space: pre-wrap;
 }
 
 .sd-warnings {
@@ -107,6 +106,7 @@
 	gap: 0.25rem;
 	list-style: none;
 	margin-block: 0;
+	white-space: pre-wrap;
 }
 
 .sd-warnings:empty::before {
@@ -140,6 +140,12 @@
 
 .sd-line-numbers:hover {
 	background-color: var(--sd-warning-item-hover-background-color);
+}
+
+.sd-console-xterm-wrapper {
+	block-size: 100%;
+	overflow: hidden;
+	position: relative;
 }
 
 /* Tabs */

--- a/src/demo.html
+++ b/src/demo.html
@@ -68,6 +68,8 @@
 	</div>
 	<div class="sd-outputs">
 		<ul class="sd-warnings"></ul>
-		<div class="sd-console"></div>
+		<div class="sd-console">
+			<div class="sd-console-xterm-wrapper"></div>
+		</div>
 	</div>
 </div>

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -53,7 +53,7 @@ export async function mount({ element, init, listeners }: MountOptions) {
 		element: element.querySelector<HTMLDivElement>('.sd-output-tabs')!,
 	});
 	const consoleOutput = setupConsoleOutput({
-		element: element.querySelector<HTMLDivElement>('.sd-console')!,
+		element: element.querySelector<HTMLDivElement>('.sd-console-xterm-wrapper')!,
 	});
 
 	consoleOutput.clear();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This PR changes to use xterm for the console display area.
The ANSI code was changed due to changes in Turborepo, so it was not displaying properly.
To solve this, change to using xterm to display the console.

before

<img width="949" alt="image" src="https://github.com/stylelint/stylelint-demo/assets/16508807/85fa3006-c459-4fbd-b6c9-df5c0cb74cd7">

after

<img width="739" alt="image" src="https://github.com/stylelint/stylelint-demo/assets/16508807/5a8640d8-d9fd-43da-92dd-f1a3cd6dd3c7">


> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
