### PR TITLE
Refactor to remove `:has()` polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/node": "^20.10.1",
         "@typescript-eslint/eslint-plugin": "^6.13.1",
         "@typescript-eslint/parser": "^6.13.1",
-        "css-has-pseudo": "^6.0.0",
         "eslint": "^8.54.0",
         "eslint-config-stylelint": "^20.0.0",
         "husky": "^8.0.3",
@@ -1935,33 +1934,6 @@
       "dev": true,
       "engines": {
         "node": ">=12 || >=16"
-      }
-    },
-    "node_modules/css-has-pseudo": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-6.0.0.tgz",
-      "integrity": "sha512-X+r+JBuoO37FBOWVNhVJhxtSBUFHgHbrcc0CjFT28JEdOw1qaDwABv/uunyodUuSy2hMPe9j/HjssxSlvUmKjg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "dependencies": {
-        "@csstools/selector-specificity": "^3.0.0",
-        "postcss-selector-parser": "^6.0.13",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4"
       }
     },
     "node_modules/css-tree": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "@types/node": "^20.10.1",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
-    "css-has-pseudo": "^6.0.0",
     "eslint": "^8.54.0",
     "eslint-config-stylelint": "^20.0.0",
     "husky": "^8.0.3",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,0 @@
-// TODO: This polyfill will be no longer needed when Firefox supports `:has()`. See https://caniuse.com/css-has
-import postcssHasPseudo from 'css-has-pseudo';
-
-export default {
-	plugins: [postcssHasPseudo()],
-};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import './style.css';
-import './polyfills';
 import { compress, decompress } from './utils/compress';
 import type { ConfigFormat } from './components/config-editor';
 import { debounce } from './utils/debounce';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,4 +1,0 @@
-// TODO: This polyfill will be no longer needed when Firefox supports `:has()`. See https://caniuse.com/css-has
-// @ts-expect-error -- TS2307: Cannot find module 'css-has-pseudo/browser' or its corresponding type declarations.
-import cssHasPseudo from 'css-has-pseudo/browser';
-cssHasPseudo(document);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #362

> Is there anything in the PR that needs further explanation?

My Firefox screenshot:

<img width="1235" alt="Screenshot 2023-12-21 at 1 17 24" src="https://github.com/stylelint/stylelint-demo/assets/473530/5f3e1919-23a8-4745-bb6e-18ee8d542784">

