### PR TITLE
Refactor to enable ESM mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "description": "Stylelint Demo",
   "repository": "stylelint/stylelint-demo",
   "license": "MIT",
-  "main": "dist/stylelint-demo.mjs",
-  "files": [
-    "dist"
-  ],
+  "type": "module",
   "scripts": {
     "clean": "node -e \"fs.rmSync('dist', {force: true, recursive: true})\"",
     "build": "vite build",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR makes this project ESM by adding `"type": "module"` to `package.json`.

By doing this, the following Vite warning disappears on `npm run build`:

```
The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
```
