### PR TITLE
Fix tab height on Firefox

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -157,7 +157,7 @@
 }
 
 .sd-input-tabs {
-	inline-size: min-content;
+	inline-size: max-content;
 }
 
 .sd-output-tabs {


### PR DESCRIPTION
The tab (Code, Config, Dependencies) is unnecessarily high, including extra margin, only on Firefox.
It's not a problem on Chrome or Safari.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

| [Before](https://chimerical-trifle-8d3c21.netlify.app/) | [After](https://deploy-preview-392--chimerical-trifle-8d3c21.netlify.app/) |
|--------|--------|
| <img width="302" alt="image" src="https://github.com/stylelint/stylelint-demo/assets/473530/40e8c8f7-e0ad-4a47-bbaa-aaa6a535ec43"> | <img width="281" alt="image" src="https://github.com/stylelint/stylelint-demo/assets/473530/83937732-0f06-4765-8842-c5825a1aa8cf"> | 
