### PR TITLE
Exclude ESLint from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
+        exclude-patterns: ['eslint']


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #401

> Is there anything in the PR that needs further explanation?

We cannot update ESLint to v9 at this point due to dependency problems. For example, see:
https://github.com/stylelint/stylelint-demo/actions/runs/8905790835/job/24456978018?pr=401#step:5:1
