### PR TITLE
Refactor CI config to use `node-version-file`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,4 +15,4 @@ jobs:
   test:
     uses: stylelint/.github/.github/workflows/test.yml@main
     with:
-      node-version: '["20"]'
+      node-version-file: .nvmrc


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

We have the `.nvmrc` file and achieve DRY:
https://github.com/stylelint/stylelint-demo/blob/fff301fe883a8c7893f8cb074042c02fdd79ef8b/.nvmrc#L1
