### PR TITLE
Fix inconsistent order of problems output between online demo and CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
           "em"
         ]
       },
+      "no-descending-specificity": null,
       "order/order": [
         [
           "custom-properties",

--- a/src/components/code-editor.ts
+++ b/src/components/code-editor.ts
@@ -24,10 +24,10 @@ export type CodeEditorOptions = {
  * This component has a filename input and a code editor.
  */
 export async function setupCodeEditor({ element, listeners, init }: CodeEditorOptions) {
-	const fileNameInput = element.querySelector<HTMLInputElement>('.sd-code-file-name')!;
+	const fileNameInput = element.querySelector<HTMLInputElement>('#sd-code-file-name')!;
 	const initFileName = adjustFileName(init.fileName);
 	const monacoEditor = await setupMonacoEditor({
-		element: element.querySelector<HTMLDivElement>('.sd-code-monaco')!,
+		element: element.querySelector<HTMLDivElement>('sd-code-monaco')!,
 		init: {
 			language: getLanguage(initFileName),
 			value: init.value ?? defaultCSS,

--- a/src/components/config-editor.ts
+++ b/src/components/config-editor.ts
@@ -29,7 +29,7 @@ export type ConfigEditorOptions = {
  * This component has a config format select and a config editor.
  */
 export async function setupConfigEditor({ element, listeners, init }: ConfigEditorOptions) {
-	const formatSelect = element.querySelector<HTMLSelectElement>('.sd-config-format')!;
+	const formatSelect = element.querySelector<HTMLSelectElement>('#sd-config-format')!;
 
 	formatSelect.innerHTML = '';
 
@@ -44,7 +44,7 @@ export async function setupConfigEditor({ element, listeners, init }: ConfigEdit
 	const initFormat = adjustFormat(init?.format || 'json');
 
 	const monacoEditor = await setupMonacoEditor({
-		element: element.querySelector<HTMLDivElement>('.sd-config-monaco')!,
+		element: element.querySelector<HTMLDivElement>('sd-config-monaco')!,
 		init: {
 			language: getLanguage(initFormat),
 			value: init?.value ?? JSON.stringify(defaultConfig, null, 2),

--- a/src/components/deps-editor.ts
+++ b/src/components/deps-editor.ts
@@ -18,10 +18,10 @@ export type DepsEditorOptions = {
 export type PackageJsonData = { name: string; version: string; homepage?: string };
 /** Setup a dependencies editor component. */
 export async function setupDepsEditor({ element, listeners, init }: DepsEditorOptions) {
-	const versionsPanel = element.querySelector<HTMLUListElement>('.sd-deps-versions')!;
+	const versionsPanel = element.querySelector<HTMLUListElement>('sd-deps-installed ul')!;
 
 	const monacoEditor = await setupMonacoEditor({
-		element: element.querySelector('.sd-deps-monaco')!,
+		element: element.querySelector('sd-deps-monaco')!,
 		init: {
 			language: 'json',
 			value: init?.value ?? JSON.stringify(defaultDeps, null, 2),
@@ -37,9 +37,6 @@ export async function setupDepsEditor({ element, listeners, init }: DepsEditorOp
 
 			for (const pkg of packages) {
 				const li = document.createElement('li');
-
-				li.classList.add('sd-deps-item');
-
 				const nameLink = document.createElement('a');
 
 				nameLink.textContent = pkg.name;

--- a/src/components/warnings.ts
+++ b/src/components/warnings.ts
@@ -15,13 +15,14 @@ export type WarningsPanelOptions = {
 export function setupWarningsPanel({ element, listeners }: WarningsPanelOptions) {
 	return {
 		setResult: (result: LinterServiceResult) => {
-			element.innerHTML = '';
+			element.innerHTML = '<ul></ul>';
+			const ul = element.querySelector('ul')!;
 
 			if (result.returnCode !== 0) {
 				const li = document.createElement('li');
 
 				li.textContent = result.result.replace(ansiRegex(), '');
-				element.appendChild(li);
+				ul.appendChild(li);
 
 				return;
 			}
@@ -36,17 +37,24 @@ export function setupWarningsPanel({ element, listeners }: WarningsPanelOptions)
 					(a.endColumn != null && b.endColumn != null && a.endColumn - b.endColumn) ||
 					0,
 			)) {
-				const ruleLinkText = `(${warning.rule})`;
-				const ruleUrl = ruleMetadata[warning.rule]?.url;
-
 				const li = document.createElement('li');
 
-				li.classList.add('sd-warning-item');
+				const lineNumbers = document.createElement('span');
+				const ln = formatPosition(warning.line, warning.endLine);
+				const col = formatPosition(warning.column, warning.endColumn);
+
+				lineNumbers.textContent = `${ln}:${col}`;
+				li.appendChild(lineNumbers);
+
+				lineNumbers.addEventListener('click', () => listeners.onClickWaning(warning));
+
+				const ruleLinkText = `(${warning.rule})`;
+				const ruleUrl = ruleMetadata[warning.rule]?.url;
 
 				const severity = document.createElement('span');
 
 				severity.textContent = warning.severity;
-				severity.classList.add(`sd-severity-${warning.severity}`);
+				severity.setAttribute('data-sd-severity', warning.severity);
 				li.appendChild(severity);
 
 				const message = document.createElement('span');
@@ -85,17 +93,7 @@ export function setupWarningsPanel({ element, listeners }: WarningsPanelOptions)
 					message.textContent = `${warning.text.trim()}`;
 				}
 
-				const lineNumbers = document.createElement('span');
-				const ln = formatPosition(warning.line, warning.endLine);
-				const col = formatPosition(warning.column, warning.endColumn);
-
-				lineNumbers.textContent = `[${ln}:${col}]`;
-				lineNumbers.classList.add('sd-line-numbers');
-				li.appendChild(lineNumbers);
-
-				lineNumbers.addEventListener('click', () => listeners.onClickWaning(warning));
-
-				element.appendChild(li);
+				ul.appendChild(li);
 			}
 		},
 	};

--- a/src/demo.css
+++ b/src/demo.css
@@ -1,214 +1,276 @@
+/* Custom properties */
 :root {
-	--sd-background-color: white;
-	--sd-color: black;
-	--sd-link-color: steelblue;
-	--sd-label-color: gray;
-	--sd-input-color: black;
-	--sd-input-border-color: gainsboro;
-	--sd-inactive-tab-color: slategray;
-	--sd-warning-item-hover-background-color: whitesmoke;
-	--sd-severity-color: white;
-	--sd-severity-error-background-color: crimson;
-	--sd-severity-warning-background-color: goldenrod;
+	--sd-black: oklch(0% 0 0deg);
+	--sd-black-a-8: oklch(from var(--sd-black) l c h / 8%);
+	--sd-gray-60: oklch(60% 0 0deg);
+	--sd-gray-90: oklch(90% 0 0deg);
+	--sd-gray-98: oklch(98% 0 0deg);
+	--sd-white: oklch(100% 0 0deg);
+	--sd-blue: oklch(50% 0.12 250deg);
+	--sd-purple: oklch(50% 0.12 285deg);
+	--sd-red: oklch(50% 0.18 20deg);
+	--sd-yellow: oklch(75% 0.14 80deg);
 }
 
-.sd {
-	color: var(--sd-color);
-	display: grid;
-	font-family: system-ui;
-	font-size: 0.875rem;
-	grid-template-rows: min-content 1fr min-content max(10rem, 33vb);
+@layer reset {
+	/* Universal */
+	* {
+		box-sizing: border-box;
+		line-height: calc(4px + 2ex);
+	}
+
+	/* Focus */
+	:focus {
+		outline: none;
+		scroll-padding-block-end: 8vb;
+	}
+
+	:focus-visible {
+		box-shadow: 0 0 0 1px var(--sd-white);
+		outline: 2px solid var(--sd-black);
+		outline-offset: 2px;
+	}
 }
 
-.sd a {
-	color: var(--sd-link-color);
-	text-decoration: none;
+@layer elements {
+	/* Sectioning root */
+	body {
+		color: var(--sd-black);
+		font-family: system-ui;
+		font-size: 0.875rem;
+		margin: 0;
+		overscroll-behavior-y: none;
+	}
+
+	/* Inline text semantics */
+	a {
+		&:any-link {
+			cursor: pointer;
+			text-decoration: none;
+		}
+
+		&:hover {
+			text-decoration: underline;
+			text-decoration-thickness: max(0.08em, 1px);
+			text-underline-offset: 0.15em;
+		}
+
+		&:link {
+			color: var(--sd-blue);
+		}
+
+		&:visited {
+			color: var(--sd-purple);
+		}
+
+		&:active {
+			color: var(--sd-red);
+		}
+	}
+
+	/* Forms */
+	label {
+		color: var(--sd-gray-60);
+		display: flex;
+		gap: 0.25rem;
+		min-block-size: 2rem;
+		padding-inline: 0.25rem;
+		place-items: center;
+	}
+
+	input,
+	select {
+		border: 1px solid var(--sd-gray-90);
+		border-radius: 2px;
+	}
 }
 
-.sd a:hover {
-	text-decoration: underline;
-}
+@layer custom-elements {
+	stylelint-demo {
+		block-size: 100dvb;
+		display: grid;
+		grid:
+			'input-tabs' min-content
+			'inputs' 1fr
+			'output-tabs' min-content
+			'outputs' max(10rem, 33vb);
 
-/* Inputs */
+		&:not(:has(input[data-radio-name='code']:checked)) sd-code,
+		&:not(:has(input[data-radio-name='config']:checked)) sd-config,
+		&:not(:has(input[data-radio-name='deps']:checked)) sd-deps {
+			display: none !important;
+		}
 
-.sd-inputs {
-	background-color: var(--sd-background-color);
-	display: grid;
-}
+		&:not(:has(input[data-radio-name='warnings']:checked)) sd-warnings,
+		&:not(:has(input[data-radio-name='console']:checked)) sd-console {
+			display: none !important;
+		}
+	}
 
-:is(.sd-code, .sd-config, .sd-deps) {
-	display: grid;
-	grid-template-rows: min-content 1fr;
-}
+	sd-input-tabs,
+	sd-output-tabs {
+		display: flex;
+		gap: 1px;
+		inline-size: 100%;
 
-:is(.sd-code, .sd-config, .sd-deps) > label {
-	color: var(--sd-label-color);
-	display: flex;
-	gap: 0.25rem;
-	min-block-size: 2rem;
-	padding-inline: 0.25rem;
-	place-items: center;
-}
+		& input[type='radio'] {
+			inline-size: 0;
+			margin: 0;
+			opacity: 0;
+		}
 
-:is(.sd-code-file-name, .sd-config-format) {
-	border: 1px solid var(--sd-input-border-color);
-	border-radius: 2px;
-}
+		& label {
+			color: var(--sd-gray-60);
+			cursor: pointer;
+			font-size: 0.75rem;
+			letter-spacing: 0.01em;
+			padding-block: 0.5rem;
+			padding-inline: 1rem;
+			text-transform: uppercase;
 
-.sd-deps {
-	display: grid;
-	grid:
-		'deps-label deps-label' min-content
-		'deps-monaco deps-installed' 1fr
-		/ 1fr 1fr;
-}
+			&:has(input[type='radio']:hover) {
+				color: var(--sd-black);
+			}
 
-.sd-deps > label {
-	grid-area: deps-label;
-}
+			&:has(input[type='radio']:checked) {
+				color: var(--sd-black);
+			}
+		}
+	}
 
-.sd-deps-monaco {
-	grid-area: deps-monaco;
-}
+	sd-input-tabs {
+		background-color: var(--sd-gray-98);
 
-.sd-deps-installed {
-	grid-area: deps-installed;
-	padding-inline: 0.5rem;
-}
+		& label {
+			&:has(input[type='radio']:checked) {
+				background-color: var(--sd-white);
+			}
+		}
+	}
 
-.sd-deps-versions {
-	list-style: none;
-	margin-block: 0;
-	padding-inline-start: 0;
-}
+	sd-output-tabs {
+		border-block-start: 1px solid var(--sd-gray-90);
+		box-shadow: 0 2px 4px 0 var(--sd-black-a-8);
 
-/* Outputs */
+		& label {
+			&:has(input[type='radio']:checked) {
+				text-decoration: underline;
+				text-underline-offset: 0.45em;
+			}
+		}
+	}
 
-.sd-outputs {
-	background-color: var(--sd-background-color);
-	box-shadow: inset 0 0 6px 0 hsl(0deg 0% 0% / 15%);
-}
+	sd-code,
+	sd-config,
+	sd-deps {
+		display: grid;
+		grid-template-rows: min-content 1fr;
+	}
 
-:is(.sd-warnings, .sd-console) {
-	block-size: 100%;
-	box-sizing: border-box;
-	font-family: monospace;
-	font-size: 0.75rem;
-	inline-size: 100%;
-	overflow: auto;
-	padding-block: 0.75rem;
-	padding-inline: 0.5rem;
-}
+	sd-deps {
+		display: grid;
+		grid:
+			'deps-label deps-label' min-content
+			'deps-monaco deps-installed' 1fr
+			/ 1fr 1fr;
 
-.sd-warnings {
-	display: flex;
-	flex-direction: column;
-	gap: 0.25rem;
-	list-style: none;
-	margin-block: 0;
-	white-space: pre-wrap;
-}
+		& label {
+			grid-area: deps-label;
+		}
 
-.sd-warnings:empty::before {
-	content: '✅ No problems!';
-}
+		& sd-deps-monaco {
+			grid-area: deps-monaco;
+		}
 
-.sd-warning-item {
-	display: flex;
-	gap: 0.5rem;
-}
+		& sd-deps-installed {
+			grid-area: deps-installed;
+			padding-inline: 0.5rem;
+		}
 
-:is(.sd-severity-error, .sd-severity-warning) {
-	color: var(--sd-severity-color);
-	flex-basis: 8ch;
-	font-size: 0.6875rem;
-	text-align: center;
-	text-transform: uppercase;
-}
+		& ul {
+			list-style: none;
+			margin-block: unset;
+			padding-inline-start: unset;
+		}
+	}
 
-.sd-severity-error {
-	background-color: var(--sd-severity-error-background-color);
-}
+	sd-outputs {
+		display: block;
+	}
 
-.sd-severity-warning {
-	background-color: var(--sd-severity-warning-background-color);
-}
+	sd-xterm-wrapper {
+		block-size: 100%;
+		display: block;
+		overflow: hidden;
+		position: relative;
+	}
 
-.sd-line-numbers {
-	cursor: pointer;
-}
+	sd-warnings,
+	sd-console {
+		block-size: 100%;
+		display: block;
+		font-family: monospace;
+		font-size: 0.75rem;
+		inline-size: 100%;
+		overflow: auto;
+		padding-block: 0.75rem;
+		padding-inline: 0.5rem;
+	}
 
-.sd-line-numbers:hover {
-	background-color: var(--sd-warning-item-hover-background-color);
-}
+	sd-warnings {
+		container: warnings / inline-size;
 
-.sd-console-xterm-wrapper {
-	block-size: 100%;
-	overflow: hidden;
-	position: relative;
-}
+		ul {
+			display: grid;
+			gap: 0.5rem 1rem;
+			list-style: none;
+			margin-block: unset;
+			max-inline-size: max-content;
+			padding-inline-start: unset;
+			white-space: pre-wrap;
 
-/* Tabs */
+			&:empty {
+				&::before {
+					content: '✅ No problems!';
+				}
+			}
 
-:is(.sd-input-tabs, .sd-output-tabs) {
-	background-color: var(--sd-background-color);
-	display: flex;
-	gap: 1px;
-}
+			& li {
+				display: grid;
+				grid-column: 1 / -1;
+				grid-template-columns: subgrid;
+				place-items: start;
 
-.sd-input-tabs {
-	inline-size: max-content;
-}
+				& span:first-child {
+					color: gray;
+					cursor: pointer;
+				}
 
-.sd-output-tabs {
-	border-block-start: 1px solid var(--sd-input-border-color);
-}
+				& span[data-sd-severity] {
+					color: var(--sd-white);
+					flex-basis: 8ch;
+					font-size: 0.6875rem;
+					text-align: center;
+					text-transform: uppercase;
+				}
 
-.sd:not(:has(.sd-code-tab:checked)) .sd-code,
-.sd:not(:has(.sd-config-tab:checked)) .sd-config,
-.sd:not(:has(.sd-deps-tab:checked)) .sd-deps {
-	display: none;
-}
+				& span[data-sd-severity='error'] {
+					background-color: var(--sd-red);
+				}
 
-.sd:not(:has(.sd-warning-tab:checked)) .sd-warnings,
-.sd:not(:has(.sd-console-tab:checked)) .sd-console {
-	display: none;
-}
+				& span[data-sd-severity='warning'] {
+					background-color: var(--sd-yellow);
+				}
 
-:is(.sd-input-tabs, .sd-output-tabs) label {
-	color: var(--sd-inactive-tab-color);
-	cursor: pointer;
-	font-size: 0.75rem;
-	letter-spacing: 0.01em;
-	padding-block: 0.5rem;
-	padding-inline: 1rem;
-	text-transform: uppercase;
-}
+				& span:nth-child(2) {
+					padding-inline: 0.25rem;
+				}
+			}
 
-.sd-input-tabs label {
-	background-color: var(--sd-warning-item-hover-background-color);
-}
-
-:is(.sd-input-tabs, .sd-output-tabs) input[type='radio'] {
-	inline-size: 0;
-	margin: 0;
-	opacity: 0;
-}
-
-:is(.sd-input-tabs, .sd-output-tabs) label:has(input[type='radio']:checked) {
-	color: var(--sd-color);
-}
-
-.sd-input-tabs label:has(input[type='radio']:checked) {
-	background-color: var(--sd-background-color);
-}
-
-.sd-output-tabs label:has(input[type='radio']:checked) {
-	text-decoration: underline;
-	text-underline-offset: 0.45em;
-}
-
-:is(.sd-input-tabs, .sd-output-tabs)
-	label:has(input[type='radio']:focus, input[type='radio']:hover) {
-	color: var(--sd-color);
+			@container warnings (width > 40em) {
+				grid-template-columns: max-content min-content 1fr max-content;
+				row-gap: 0.25rem;
+			}
+		}
+	}
 }

--- a/src/demo.html
+++ b/src/demo.html
@@ -1,75 +1,44 @@
-<div class="sd">
-	<div class="sd-input-tabs">
+<stylelint-demo>
+	<sd-input-tabs>
 		<label>
-			<input
-				type="radio"
-				name="stylelint_input_tabs"
-				class="sd-code-tab"
-				data-radio-name="code"
-				checked
-			/>Code
+			<input type="radio" name="stylelint_input_tabs" data-radio-name="code" checked />Code
 		</label>
 		<label>
-			<input
-				type="radio"
-				name="stylelint_input_tabs"
-				class="sd-config-tab"
-				data-radio-name="config"
-			/>Config
+			<input type="radio" name="stylelint_input_tabs" data-radio-name="config" />Config
 		</label>
 		<label>
-			<input
-				type="radio"
-				name="stylelint_input_tabs"
-				class="sd-deps-tab"
-				data-radio-name="deps"
-			/>Dependencies
+			<input type="radio" name="stylelint_input_tabs" data-radio-name="deps" />Dependencies
 		</label>
-	</div>
-	<div class="sd-inputs">
-		<div class="sd-code">
-			<label>› <input type="text" class="sd-code-file-name" /></label>
-			<div class="sd-code-monaco"></div>
-		</div>
-		<div class="sd-config">
-			<label
-				>› .stylelintrc.
-				<select type="text" class="sd-config-format"></select>
-			</label>
-			<div class="sd-config-monaco"></div>
-		</div>
-		<div class="sd-deps">
-			<label>› package.json</label>
-			<div class="sd-deps-monaco"></div>
-			<div class="sd-deps-installed">
-				<label>Installed:</label>
-				<ul class="sd-deps-versions"></ul>
-			</div>
-		</div>
-	</div>
-	<div class="sd-output-tabs">
+	</sd-input-tabs>
+	<sd-code>
+		<label>› <input type="text" id="sd-code-file-name" /></label>
+		<sd-code-monaco></sd-code-monaco>
+	</sd-code>
+	<sd-config>
+		<label
+			>› .stylelintrc.
+			<select type="text" id="sd-config-format"></select>
+		</label>
+		<sd-config-monaco></sd-config-monaco>
+	</sd-config>
+	<sd-deps>
+		<label>› package.json</label>
+		<sd-deps-monaco></sd-deps-monaco>
+		<sd-deps-installed>
+			<label>Installed:</label>
+			<ul></ul>
+		</sd-deps-installed>
+	</sd-deps>
+	<sd-output-tabs>
 		<label>
-			<input
-				type="radio"
-				name="stylelint_output_tabs"
-				class="sd-warning-tab"
-				data-radio-name="warnings"
-				checked
-			/>Problems
+			<input type="radio" name="stylelint_output_tabs" data-radio-name="warnings" checked />Problems
 		</label>
 		<label>
-			<input
-				type="radio"
-				name="stylelint_output_tabs"
-				class="sd-console-tab"
-				data-radio-name="console"
-			/>Console
+			<input type="radio" name="stylelint_output_tabs" data-radio-name="console" />Console
 		</label>
-	</div>
-	<div class="sd-outputs">
-		<ul class="sd-warnings"></ul>
-		<div class="sd-console">
-			<div class="sd-console-xterm-wrapper"></div>
-		</div>
-	</div>
-</div>
+	</sd-output-tabs>
+	<sd-outputs>
+		<sd-warnings></sd-warnings>
+		<sd-console><sd-xterm-wrapper></sd-xterm-wrapper></sd-console>
+	</sd-outputs>
+</stylelint-demo>

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -47,20 +47,20 @@ export async function mount({ element, init, listeners }: MountOptions) {
 	element.innerHTML = html;
 
 	const inputTabs = setupTabs({
-		element: element.querySelector<HTMLDivElement>('.sd-input-tabs')!,
+		element: element.querySelector<HTMLDivElement>('sd-input-tabs')!,
 	});
 	const outputTabs = setupTabs({
-		element: element.querySelector<HTMLDivElement>('.sd-output-tabs')!,
+		element: element.querySelector<HTMLDivElement>('sd-output-tabs')!,
 	});
 	const consoleOutput = setupConsoleOutput({
-		element: element.querySelector<HTMLDivElement>('.sd-console-xterm-wrapper')!,
+		element: element.querySelector<HTMLDivElement>('sd-xterm-wrapper')!,
 	});
 
 	consoleOutput.clear();
 	consoleOutput.appendLine('Setup...');
 
 	const warningsPanel = setupWarningsPanel({
-		element: element.querySelector<HTMLDivElement>('.sd-warnings')!,
+		element: element.querySelector<HTMLDivElement>('sd-warnings')!,
 		listeners: {
 			onClickWaning(warning) {
 				const editor = codeEditor.getLeftEditor();
@@ -80,7 +80,7 @@ export async function mount({ element, init, listeners }: MountOptions) {
 	});
 	const [codeEditor, configEditor, depsEditor, lintServer, monaco] = await Promise.all([
 		setupCodeEditor({
-			element: element.querySelector<HTMLDivElement>('.sd-code')!,
+			element: element.querySelector<HTMLDivElement>('sd-code')!,
 			listeners: {
 				onChangeValue: debounce(async (value) => {
 					onChangeValues({
@@ -96,7 +96,7 @@ export async function mount({ element, init, listeners }: MountOptions) {
 			init: { value: init?.code, fileName: init?.fileName },
 		}),
 		setupConfigEditor({
-			element: element.querySelector<HTMLDivElement>('.sd-config')!,
+			element: element.querySelector<HTMLDivElement>('sd-config')!,
 			listeners: {
 				onChangeValue: debounce(async (value) => {
 					onChangeValues({
@@ -112,7 +112,7 @@ export async function mount({ element, init, listeners }: MountOptions) {
 			init: { value: init?.config, format: init?.configFormat },
 		}),
 		setupDepsEditor({
-			element: element.querySelector<HTMLDivElement>('.sd-deps')!,
+			element: element.querySelector<HTMLDivElement>('sd-deps')!,
 			listeners: {
 				onChangeValue: debounce(async (value) => {
 					if (!(await updateDependencies(value))) {

--- a/src/monaco-editor/monaco-setup.ts
+++ b/src/monaco-editor/monaco-setup.ts
@@ -93,6 +93,8 @@ export async function setupMonacoEditor({
 		colorDecorators: false,
 		renderControlCharacters: false,
 		renderIndentGuides: false,
+		renderOverviewRuler: false,
+		lineNumbersMinChars: 3,
 		renderValidationDecorations: 'on' as const,
 		renderWhitespace: 'boundary' as const,
 		scrollBeyondLastLine: false,

--- a/src/style.css
+++ b/src/style.css
@@ -1,12 +1,4 @@
-body {
-	background-color: whitesmoke;
-	margin: 0;
-	overscroll-behavior-y: none;
-}
-
 #app {
 	block-size: 100dvb;
 	display: grid;
-	min-inline-size: 48rem;
-	overflow-x: scroll;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None. I've been catching up on issues and PRs across the Stylelint org (amazing work btw!), and I wanted to dip my authoring toe back in with some CSS coding. 

> Is there anything in the PR that needs further explanation?

This PR changes the output order to match the string formatter for consistency between the CLI and the online demo (location, severity, description, and name), as it's likely users of the online demo are reproducing an issue they first saw on the CLI.

Old:

<img width="730" alt="Screenshot 2024-07-31 at 10 37 57" src="https://github.com/user-attachments/assets/f32f7c2e-498d-4833-a8ff-ecd760a7a009">

New:

<img width="844" alt="Screenshot 2024-07-31 at 10 15 29" src="https://github.com/user-attachments/assets/f3cd099c-c072-4340-8a83-0e88aca356b9">

CLI (for reference):

<img width="733" alt="Screenshot 2024-07-31 at 10 34 49" src="https://github.com/user-attachments/assets/e36aa69d-b50e-4c50-827d-7b5139b0ac8b">

To help make the fix, I also refactored [the CSS](https://github.com/stylelint/stylelint-demo/compare/fix-order-of-warnings-output?expand=1#diff-b4fde7f60d3bcf85b4177cf31a84117f0a1dec4b2da06e177c9e2b131d5dee38) and HTML code to use the type of modern features we'd like Stylelint to help authors to adopt:

- cascade layers
- `oklch()` colour format
- relative colours
- nesting
- container queries
- subgrid
- custom elements (styled in the light)

(I would've liked to have used `clamp()` for fluid spacing and type sizes, but the Monoco editor isn't fluid so it doesn't make sense to.)

I've kept using the existing modern features like:

- named grid areas
- math comparison functions
- the `:has()` pseudo-class
- logical properties and values

Hopefully, this refactor will make the CSS code more straightforward to navigate and work with as it more closely groups related styles.
