### PR TITLE
Fix Vite build deprecation warning

### DIFF
--- a/src/linter-service/index.ts
+++ b/src/linter-service/index.ts
@@ -64,7 +64,7 @@ export async function setupLintServer({
 	const serverFiles: FileSystemTree = {};
 
 	for (const [file, contents] of Object.entries(
-		import.meta.glob('./server/**/*.mjs', { as: 'raw' }),
+		import.meta.glob('./server/**/*.mjs', { query: '?raw', import: 'default' }),
 	).map(([file, load]) => {
 		return [file.slice(9), load() as Promise<string>] as const;
 	})) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

```
The glob option "as" has been deprecated in favour of "query". Please update `as: 'raw'` to `query: '?raw', import: 'default'`.
```

Ref https://vitejs.dev/guide/features#custom-queries

---

<img width="895" alt="Screenshot 2024-08-01 at 22 27 18" src="https://github.com/user-attachments/assets/db7f7401-42fc-409d-a6aa-27eace8973a9">


-- https://github.com/stylelint/stylelint-demo/actions/runs/10199201496/job/28215751741#step:9:15
