### PR TITLE
Fix background color on dark mode

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -87,6 +87,7 @@
 
 @layer custom-elements {
 	stylelint-demo {
+		background-color: var(--sd-white);
 		block-size: 100dvb;
 		display: grid;
 		grid:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #413

> Is there anything in the PR that needs further explanation?

I came across this issue on the dark mode supported by the demo site (https://stylelint.io/demo).

To reproduce it locally, edit `src/demo.css` like this:

```diff
 	/* Sectioning root */
 	body {
+		background-color: black;
 		color: var(--sd-black);
```
