### PR TITLE
Support namespaces not starting with `@` or of length 1

### DIFF
--- a/src/schema/stylelintrc.json
+++ b/src/schema/stylelintrc.json
@@ -5153,7 +5153,7 @@
 				}
 			},
 			"patternProperties": {
-				"@[a-z\\d][\\w.-]+/.+": {
+				"[a-z\\d@][\\w.-]*/.+": {
 					"oneOf": [
 						{
 							"oneOf": [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #445

> Is there anything in the PR that needs further explanation?

examples of npm accounts of length 1
https://www.npmjs.com/~1
https://www.npmjs.com/~a