### PR TITLE
Refactor to remove useless `@types/*` packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,6 @@
       "devDependencies": {
         "@stylelint/prettier-config": "^3.0.0",
         "@stylelint/remark-preset": "^5.1.1",
-        "@types/chokidar": "^2.1.7",
-        "@types/eslint__js": "^8.42.3",
-        "@types/lz-string": "^1.5.0",
-        "@types/node": "^22.13.0",
         "eslint": "^9.19.0",
         "eslint-config-stylelint": "^23.0.0",
         "globals": "^15.14.0",
@@ -1496,17 +1492,6 @@
         "eslint": ">=8.40.0"
       }
     },
-    "node_modules/@types/chokidar": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.7.tgz",
-      "integrity": "sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig==",
-      "deprecated": "This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "*"
-      }
-    },
     "node_modules/@types/concat-stream": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-2.0.3.tgz",
@@ -1525,27 +1510,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint__js": {
-      "version": "8.42.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
-      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -1595,17 +1559,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-s84fKOrzqqNCAPljhVyC5TjAo6BH4jKHw9NRNFNiRUY5QSgZCmVm5XILlWbisiKl+0OcS7eWihmKGS5akc2iQw==",
-      "deprecated": "This is a stub types definition. lz-string provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lz-string": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -2294,22 +2247,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ci-info": {
@@ -6663,20 +6600,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/refa": {

--- a/package.json
+++ b/package.json
@@ -99,10 +99,6 @@
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
     "@stylelint/remark-preset": "^5.1.1",
-    "@types/chokidar": "^2.1.7",
-    "@types/eslint__js": "^8.42.3",
-    "@types/lz-string": "^1.5.0",
-    "@types/node": "^22.13.0",
     "eslint": "^9.19.0",
     "eslint-config-stylelint": "^23.0.0",
     "globals": "^15.14.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change is generated by the following command:

```shell
npm rm @types/chokidar @types/eslint__js @types/lz-string @types/node
```
