### PR TITLE
Update monaco-editor to 0.54.0 and load it from ESM CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@webcontainer/api": "^1.6.1",
         "ansi-regex": "^6.2.2",
         "lz-string": "^1.5.0",
-        "monaco-editor": "^0.53.0",
+        "monaco-editor": "^0.54.0",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0"
       },
@@ -36,7 +36,7 @@
         "vite": "^7.1.12"
       },
       "engines": {
-        "node": "22"
+        "node": "24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1684,12 +1684,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "license": "MIT"
-    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2800,6 +2794,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4798,6 +4798,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -5587,12 +5599,13 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.53.0.tgz",
-      "integrity": "sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "license": "MIT",
       "dependencies": {
-        "@types/trusted-types": "^1.0.6"
+        "dompurify": "3.1.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@webcontainer/api": "^1.6.1",
     "ansi-regex": "^6.2.2",
     "lz-string": "^1.5.0",
-    "monaco-editor": "^0.53.0",
+    "monaco-editor": "^0.54.0",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0"
   },

--- a/src/monaco-editor/monaco-loader.ts
+++ b/src/monaco-editor/monaco-loader.ts
@@ -11,7 +11,8 @@ export function loadMonaco(): Promise<Monaco> {
 	return (
 		monacoPromise ||
 		(monacoPromise = (async () => {
-			const rawMonaco: Monaco | { m: Monaco } = await loadModuleFromMonaco('vs/editor/editor.main');
+			const rawMonaco: Monaco | { m: Monaco } =
+				(await loadMonacoFromEsmCdn()) || (await loadModuleFromMonaco('vs/editor/editor.main'));
 
 			let monaco: Monaco;
 
@@ -51,6 +52,24 @@ export function loadMonaco(): Promise<Monaco> {
 	);
 }
 
+async function loadMonacoFromEsmCdn(): Promise<Monaco | null> {
+	try {
+		const result = await import(`https://cdn.jsdelivr.net/npm/monaco-editor@${monacoVersion}/+esm`);
+
+		const link = document.createElement('link');
+
+		link.rel = 'stylesheet';
+		link.href = `https://cdn.jsdelivr.net/npm/monaco-editor@${monacoVersion}/min/vs/editor/editor.main.css`;
+		document.head.append(link);
+
+		return result as Monaco;
+	} catch (e: unknown) {
+		console.warn('Failed to load Monaco editor from ESM CDN.', e);
+
+		return null;
+	}
+}
+
 async function loadModuleFromMonaco<T>(moduleName: string): Promise<T> {
 	await setupMonaco();
 
@@ -83,7 +102,7 @@ async function appendMonacoEditorScript(): Promise<HTMLScriptElement> {
 	const script = document.createElement('script');
 
 	return new Promise((resolve) => {
-		script.src = `https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/${monacoVersion}/min/vs/loader.min.js`;
+		script.src = `https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.53.0/min/vs/loader.min.js`;
 		script.onload = () => {
 			script.onload = null;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #496
Closes https://github.com/stylelint/stylelint-demo/issues/493

> Is there anything in the PR that needs further explanation?

This pull request updates the monaco-editor version to 0.54 and changes it to be loaded as an ESM module from a CDN.
Also, the CDN will be changed to jsdelivr.

However, I'm still not sure if this is the correct implementation method. I haven't yet found any posts regarding best practices for using monaco-editor with ESM via a CDN.

In this pull request, as a precaution, if loading the ESM using the CDN fails, it will fall back to loading it using the previous method (v0.53 with AMD).