### PR TITLE
Add dark mode support

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -2,14 +2,26 @@
 :root {
 	--sd-black: oklch(0% 0 0deg);
 	--sd-black-a-8: oklch(from var(--sd-black) l c h / 8%);
+	--sd-gray-20: oklch(20% 0 0deg);
+	--sd-gray-25: oklch(25% 0 0deg);
 	--sd-gray-60: oklch(60% 0 0deg);
 	--sd-gray-90: oklch(90% 0 0deg);
 	--sd-gray-98: oklch(98% 0 0deg);
 	--sd-white: oklch(100% 0 0deg);
+	--sd-white-a-8: oklch(from var(--sd-white) l c h / 8%);
 	--sd-blue: oklch(50% 0.12 250deg);
 	--sd-purple: oklch(50% 0.12 285deg);
 	--sd-red: oklch(50% 0.18 20deg);
 	--sd-yellow: oklch(75% 0.14 80deg);
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--sd-blue: oklch(60% 0.12 250deg);
+		--sd-purple: oklch(60% 0.12 285deg);
+		--sd-red: oklch(60% 0.18 20deg);
+		--sd-yellow: oklch(60% 0.14 80deg);
+	}
 }
 
 @layer reset {
@@ -40,6 +52,10 @@
 		font-size: 0.875rem;
 		margin: 0;
 		overscroll-behavior-y: none;
+
+		@media (prefers-color-scheme: dark) {
+			color: var(--sd-white);
+		}
 	}
 
 	/* Inline text semantics */
@@ -76,12 +92,22 @@
 		min-block-size: 2rem;
 		padding-inline: 0.25rem;
 		place-items: center;
+
+		@media (prefers-color-scheme: dark) {
+			color: var(--sd-gray-90);
+		}
 	}
 
 	input,
 	select {
 		border: 1px solid var(--sd-gray-90);
 		border-radius: 2px;
+
+		@media (prefers-color-scheme: dark) {
+			background-color: var(--sd-gray-20);
+			border: 1px solid var(--sd-gray-25);
+			color: var(--sd-white);
+		}
 	}
 }
 
@@ -105,6 +131,10 @@
 		&:not(:has(input[data-radio-name='warnings']:checked)) sd-warnings,
 		&:not(:has(input[data-radio-name='console']:checked)) sd-console {
 			display: none !important;
+		}
+
+		@media (prefers-color-scheme: dark) {
+			background-color: var(--sd-gray-20);
 		}
 	}
 
@@ -131,10 +161,22 @@
 
 			&:has(input[type='radio']:hover) {
 				color: var(--sd-black);
+
+				@media (prefers-color-scheme: dark) {
+					color: var(--sd-white);
+				}
 			}
 
 			&:has(input[type='radio']:checked) {
 				color: var(--sd-black);
+
+				@media (prefers-color-scheme: dark) {
+					color: var(--sd-white);
+				}
+			}
+
+			@media (prefers-color-scheme: dark) {
+				color: var(--sd-gray-90);
 			}
 		}
 	}
@@ -145,7 +187,15 @@
 		& label {
 			&:has(input[type='radio']:checked) {
 				background-color: var(--sd-white);
+
+				@media (prefers-color-scheme: dark) {
+					background-color: var(--sd-gray-25);
+				}
 			}
+		}
+
+		@media (prefers-color-scheme: dark) {
+			background-color: var(--sd-gray-20);
 		}
 	}
 
@@ -158,6 +208,12 @@
 				text-decoration: underline;
 				text-underline-offset: 0.45em;
 			}
+		}
+
+		@media (prefers-color-scheme: dark) {
+			background-color: var(--sd-gray-25);
+			border-block-start: 1px solid var(--sd-gray-25);
+			box-shadow: 0 2px 4px 0 var(--sd-white-a-8);
 		}
 	}
 

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -146,6 +146,14 @@ export async function mount({ element, init, listeners }: MountOptions) {
 		loadMonaco(),
 	]);
 
+	const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+	const updateTheme = () => {
+		monaco.editor.setTheme(mediaQuery.matches ? 'vs-dark' : 'vs');
+	};
+
+	updateTheme();
+	mediaQuery.addEventListener('change', updateTheme);
+
 	let seq = 0;
 
 	if (await updateDependencies(depsEditor.getValue())) {
@@ -165,6 +173,7 @@ export async function mount({ element, init, listeners }: MountOptions) {
 			configEditor.disposeEditor();
 			depsEditor.disposeEditor();
 			await lintServer.teardown();
+			mediaQuery.removeEventListener('change', updateTheme);
 			element.innerHTML = '';
 		},
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #456 

> Is there anything in the PR that needs further explanation?

I figured I'd work on this issue as I was laid up for some of last week with a migraine, and when I looked at the Stylelint website on my phone (always in dark mode) the bright white demo page was blinding.

The PR changes the app (CSS and Monaco theme) to respect a user's system preference.

https://github.com/user-attachments/assets/f3a62be8-ba93-445a-b142-14be5a869d68

I've added additional _primitive_ variables to use directly in the components rather than adding another layer of abstraction using _semantic_ variables, as this keeps things simple.

Related PR to https://github.com/stylelint/stylelint.io/pull/552. There may be a way to tie the demo into the Docusaurus switcher, but respecting the system preference in both (and removing the switcher) seemed the most straightforward approach for now.