### PR TITLE
Refactor to use `light-dark()` function for dark mode support

### DIFF
--- a/src/demo.css
+++ b/src/demo.css
@@ -9,19 +9,12 @@
 	--sd-gray-98: oklch(98% 0 0deg);
 	--sd-white: oklch(100% 0 0deg);
 	--sd-white-a-8: oklch(from var(--sd-white) l c h / 8%);
-	--sd-blue: oklch(50% 0.12 250deg);
-	--sd-purple: oklch(50% 0.12 285deg);
-	--sd-red: oklch(50% 0.18 20deg);
-	--sd-yellow: oklch(75% 0.14 80deg);
-}
+	--sd-blue: light-dark(oklch(50% 0.12 250deg), oklch(60% 0.12 250deg));
+	--sd-purple: light-dark(oklch(50% 0.12 285deg), oklch(60% 0.12 285deg));
+	--sd-red: light-dark(oklch(50% 0.18 20deg), oklch(60% 0.18 20deg));
+	--sd-yellow: light-dark(oklch(75% 0.14 80deg), oklch(60% 0.14 80deg));
 
-@media (prefers-color-scheme: dark) {
-	:root {
-		--sd-blue: oklch(60% 0.12 250deg);
-		--sd-purple: oklch(60% 0.12 285deg);
-		--sd-red: oklch(60% 0.18 20deg);
-		--sd-yellow: oklch(60% 0.14 80deg);
-	}
+	color-scheme: light dark;
 }
 
 @layer reset {
@@ -47,15 +40,11 @@
 @layer elements {
 	/* Sectioning root */
 	body {
-		color: var(--sd-black);
+		color: light-dark(var(--sd-black), var(--sd-white));
 		font-family: system-ui;
 		font-size: 0.875rem;
 		margin: 0;
 		overscroll-behavior-y: none;
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--sd-white);
-		}
 	}
 
 	/* Inline text semantics */
@@ -86,34 +75,26 @@
 
 	/* Forms */
 	label {
-		color: var(--sd-gray-60);
+		color: light-dark(var(--sd-gray-60), var(--sd-gray-90));
 		display: flex;
 		gap: 0.25rem;
 		min-block-size: 2rem;
 		padding-inline: 0.25rem;
 		place-items: center;
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--sd-gray-90);
-		}
 	}
 
 	input,
 	select {
-		border: 1px solid var(--sd-gray-90);
+		background-color: light-dark(transparent, var(--sd-gray-20));
+		border: 1px solid light-dark(var(--sd-gray-90), var(--sd-gray-25));
 		border-radius: 2px;
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--sd-gray-20);
-			border: 1px solid var(--sd-gray-25);
-			color: var(--sd-white);
-		}
+		color: light-dark(initial, var(--sd-white));
 	}
 }
 
 @layer custom-elements {
 	stylelint-demo {
-		background-color: var(--sd-white);
+		background-color: light-dark(var(--sd-white), var(--sd-gray-20));
 		block-size: 100dvb;
 		display: grid;
 		grid:
@@ -132,10 +113,6 @@
 		&:not(:has(input[data-radio-name='console']:checked)) sd-console {
 			display: none !important;
 		}
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--sd-gray-20);
-		}
 	}
 
 	sd-input-tabs,
@@ -151,7 +128,7 @@
 		}
 
 		& label {
-			color: var(--sd-gray-60);
+			color: light-dark(var(--sd-gray-60), var(--sd-gray-90));
 			cursor: pointer;
 			font-size: 0.75rem;
 			letter-spacing: 0.01em;
@@ -160,60 +137,35 @@
 			text-transform: uppercase;
 
 			&:has(input[type='radio']:hover) {
-				color: var(--sd-black);
-
-				@media (prefers-color-scheme: dark) {
-					color: var(--sd-white);
-				}
+				color: light-dark(var(--sd-black), var(--sd-white));
 			}
 
 			&:has(input[type='radio']:checked) {
-				color: var(--sd-black);
-
-				@media (prefers-color-scheme: dark) {
-					color: var(--sd-white);
-				}
-			}
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--sd-gray-90);
+				color: light-dark(var(--sd-black), var(--sd-white));
 			}
 		}
 	}
 
 	sd-input-tabs {
-		background-color: var(--sd-gray-98);
+		background-color: light-dark(var(--sd-gray-98), var(--sd-gray-20));
 
 		& label {
 			&:has(input[type='radio']:checked) {
-				background-color: var(--sd-white);
-
-				@media (prefers-color-scheme: dark) {
-					background-color: var(--sd-gray-25);
-				}
+				background-color: light-dark(var(--sd-white), var(--sd-gray-25));
 			}
-		}
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--sd-gray-20);
 		}
 	}
 
 	sd-output-tabs {
-		border-block-start: 1px solid var(--sd-gray-90);
-		box-shadow: 0 2px 4px 0 var(--sd-black-a-8);
+		background-color: light-dark(transparent, var(--sd-gray-25));
+		border-block-start: 1px solid light-dark(var(--sd-gray-90), var(--sd-gray-25));
+		box-shadow: 0 2px 4px 0 light-dark(var(--sd-black-a-8), var(--sd-white-a-8));
 
 		& label {
 			&:has(input[type='radio']:checked) {
 				text-decoration: underline;
 				text-underline-offset: 0.45em;
 			}
-		}
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--sd-gray-25);
-			border-block-start: 1px solid var(--sd-gray-25);
-			box-shadow: 0 2px 4px 0 var(--sd-white-a-8);
 		}
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint-demo/pull/501

> Is there anything in the PR that needs further explanation?

@ota-meshi Thanks for the quick merge and review of https://github.com/stylelint/stylelint-demo/pull/501. I forgot about the newer `light-dark()` function in my original implementation, so I've opened this refactor PR. Using `light-dark()` makes it easier to see which colours are used, as the conditionals are contained within the declarations rather than in separate `@media` at-rules.

see also https://caniuse.com/wf-light-dark