### PR TITLE
Add support for ESM configs

### DIFF
--- a/src/components/defaults/config.json
+++ b/src/components/defaults/config.json
@@ -1,3 +1,0 @@
-{
-	"extends": ["stylelint-config-standard"]
-}

--- a/src/components/defaults/config.mjs
+++ b/src/components/defaults/config.mjs
@@ -1,0 +1,3 @@
+export default {
+	extends: ['stylelint-config-standard'],
+};

--- a/src/demo.html
+++ b/src/demo.html
@@ -16,7 +16,7 @@
 	</sd-code>
 	<sd-config>
 		<label
-			>› .stylelintrc.
+			>›
 			<select type="text" id="sd-config-format"></select>
 		</label>
 		<sd-config-monaco></sd-config-monaco>

--- a/src/linter-service/server/server.mjs
+++ b/src/linter-service/server/server.mjs
@@ -28,22 +28,15 @@ const RESERVED_FILE_NAMES = [
 	'.stylelintrc.yml',
 	'stylelint.config.cjs',
 	'stylelint.config.js',
+	'stylelint.config.mjs',
 	'.stylelintignore',
 ];
 
 const CONFIG_FORMATS = [
-	{
-		id: 'json',
-		name: '.stylelintrc.json',
-	},
-	{
-		id: 'js',
-		name: 'stylelint.config.cjs',
-	},
-	{
-		id: 'yaml',
-		name: '.stylelintrc.yaml',
-	},
+	'stylelint.config.mjs',
+	'stylelint.config.cjs',
+	'.stylelintrc.json',
+	'.stylelintrc.yaml',
 ];
 
 /**
@@ -109,18 +102,15 @@ async function lint(input) {
 			);
 		}
 
-		const configFile = path.join(
-			SRC_DIR,
-			CONFIG_FORMATS.find((f) => f.id === input.configFormat)?.name ?? '.stylelintrc.json',
-		);
+		const configFile = path.join(SRC_DIR, input.configFormat);
 
 		fs.mkdirSync(path.dirname(targetFile), { recursive: true });
 		fs.mkdirSync(path.dirname(configFile), { recursive: true });
 
 		for (const configFormat of CONFIG_FORMATS) {
-			if (configFormat.id === input.configFormat) continue;
+			if (configFormat === input.configFormat) continue;
 
-			const otherConfigFile = path.join(SRC_DIR, configFormat.name);
+			const otherConfigFile = path.join(SRC_DIR, configFormat);
 
 			if (fs.existsSync(otherConfigFile)) fs.unlinkSync(otherConfigFile);
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './style.css';
 import { compress, decompress } from './utils/compress';
 import type { ConfigFormat } from './components/config-editor';
 import { debounce } from './utils/debounce';
-import defaultConfig from './components/defaults/config.json';
+import defaultConfig from './components/defaults/config.mjs';
 import defaultDeps from './components/defaults/deps';
 import { mount } from './demo';
 
@@ -64,6 +64,19 @@ if (queryParam.syntax) {
 		} catch {
 			// ignore
 		}
+	}
+}
+
+// Backward compatibility for old file format picker
+if (queryParam.configFormat) {
+	const format = queryParam.configFormat.trim().toLowerCase();
+
+	if (format === 'json') {
+		queryParam.configFormat = '.stylelintrc.json';
+	} else if (format === 'yaml') {
+		queryParam.configFormat = '.stylelintrc.yaml';
+	} else if (format === 'js') {
+		queryParam.configFormat = 'stylelint.config.cjs';
 	}
 }
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #504

> Is there anything in the PR that needs further explanation?

Before:

https://github.com/user-attachments/assets/328f2fb1-efa4-48d3-bd17-0009c706c960

After:

https://github.com/user-attachments/assets/e7b1f84d-9cc1-44e2-9798-ac42104db648

I'm not very familiar with this codebase outside of the CSS, so I may have missed something. I've kept the changes to a minimum.

The config format is now the full filename rather than appending an extension to `.stylelintrc`.

I've added backwards compatibility for existing links that used the old extension picker, e.g.:

- [JSON](https://deploy-preview-505--chimerical-trifle-8d3c21.netlify.app/#N4Igxg9gJgpiBcIACBbGUCWBDABACgHcMoAXACxwB4BeHAOwGcA6AEgDcsAnASh2AF8QAGhAAzDABsYAOSxoEIGAA85ABylMGYBg2HgIdcQHMFwADp0cOMyE4BXKQxvw+Fq1ZtpMWALSiYWCR2nDA+dHKhdBA+dnQA1lEEdM44JPYwbjj8FoIikIYYRgBiEJwogQoAVgwGerCquojmljYMJACeUhIYdCQpNgB6AIwAbEwATAAMTJM2OSD8QA)
- [(Common) JS](https://deploy-preview-505--chimerical-trifle-8d3c21.netlify.app/#N4Igxg9gJgpiBcICGACYAdAdugLgcwCcBLKAWhxgFsAHAGyQtKQJiQGd4tdcByVJHlxy8ARijEieAbiGRaBeCgAWbegAoATAAYANCgCMWgKR6AzMb0BWIwEoZmAL5dMqDNhylSAMQgRF+lkp7J0wQHRAAMyJaGAA5JEo4RBgADwS6GAA6MDY2MPAITCi8BBBKaABXGMzU6ggCHDYUAF40LBQUdBBUikwoNi7FAG12js6QNhwATxjaIkwPSCKiPFJJpD7mKC7RgF0sB3yl4p8CSgZSgCs88NhqPMQ3Dq7JmZg5hcHx+gpJrp1Ri9prN5otCsU1jgNlAtl8uj8YH8QAcQA4gA)

(Links taken from issues in our tracker.)

