### PR TITLE
Modernise Stylelint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,10 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.3",
         "remark-cli": "^12.0.1",
-        "stylelint": "^17.9.0",
+        "stylelint": "^17.10.0",
+        "stylelint-config-alphabetical-order": "^2.0.0",
+        "stylelint-config-modern": "^1.0.0",
         "stylelint-config-standard": "^40.0.0",
-        "stylelint-order": "^8.1.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.0",
         "vite": "^8.0.10"
@@ -6379,9 +6380,9 @@
       }
     },
     "node_modules/postcss-sorting": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-10.0.0.tgz",
-      "integrity": "sha512-TXbU+h6vVRW+86c/+ewhWq9k7pr7ijASTnepVhCQiC87zAOTkvB1v2dHyWP+ggstSTX/PNvjzS+IOqzejndz9w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-9.1.0.tgz",
+      "integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7746,9 +7747,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.9.0.tgz",
-      "integrity": "sha512-xO0jeY6z1/urFL5L/BZLmB1yYlbRiRMQnYH6ArZIDWJ+SZXGssOY7XoYb1JIv/L220+EBnwwJXJS4Mt/F96SvA==",
+      "version": "17.10.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.10.0.tgz",
+      "integrity": "sha512-cI7I6HHEYOHHVNVci+s92WlA3QfmNhjwFdgCgYV3TLEysilOjk+B3EFxMED1xY9GYB0Kre3OD+mSLj19VLTIvA==",
       "dev": true,
       "funding": [
         {
@@ -7789,7 +7790,7 @@
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.9",
+        "postcss": "^8.5.13",
         "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -7804,6 +7805,29 @@
       },
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-alphabetical-order": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-alphabetical-order/-/stylelint-config-alphabetical-order-2.0.0.tgz",
+      "integrity": "sha512-oI72VCiqyuB8X0JZzDTPDoX1eicWwUCrvtXaWiiLNuz6pSnt9yL+ZE+q08BQSZdwlmtneG6eDo/XRCOaOX5ARg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-order": "^7.0.0"
+      }
+    },
+    "node_modules/stylelint-config-modern": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-modern/-/stylelint-config-modern-1.0.0.tgz",
+      "integrity": "sha512-VANS74C6vgiLPhFqzN25gLtLCpV6SszMJ4ZsGI8kvcrdFJez8/s3Utfyv7CHpBRxggeC+mLOe1Ma+VYs1Ppbdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.10.0"
       }
     },
     "node_modules/stylelint-config-recommended": {
@@ -7856,14 +7880,14 @@
       }
     },
     "node_modules/stylelint-order": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-8.1.1.tgz",
-      "integrity": "sha512-LqsEB6VggJuu5v10RtkrQsBObcdwBE7GuAOlwfc/LR3VL/w8UqKX2BOLIjhyGt0Gne/njo7gRNGiJAKhfmPMNw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-7.0.1.tgz",
+      "integrity": "sha512-GWPei1zBVDDjxM+/BmcSCiOcHNd8rSqW6FUZtqQGlTRpD0Z5nSzspzWD8rtKif5KPdzUG68DApKEV/y/I9VbTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss": "^8.5.8",
-        "postcss-sorting": "^10.0.0"
+        "postcss": "^8.5.6",
+        "postcss-sorting": "^9.1.0"
       },
       "engines": {
         "node": ">=20.19.0"

--- a/package.json
+++ b/package.json
@@ -39,13 +39,11 @@
   },
   "stylelint": {
     "extends": [
-      "stylelint-config-standard"
-    ],
-    "plugins": [
-      "stylelint-order"
+      "stylelint-config-standard",
+      "stylelint-config-modern",
+      "stylelint-config-alphabetical-order"
     ],
     "rules": {
-      "declaration-property-value-no-unknown": true,
       "declaration-property-unit-allowed-list": {
         "/^border$|^border.*(width$|block$|inline$|start$|end$/|radius$)": [
           "px"
@@ -68,23 +66,9 @@
         ]
       },
       "no-descending-specificity": null,
-      "order/order": [
-        [
-          "custom-properties",
-          "declarations",
-          "rules",
-          "at-rules"
-        ],
-        {
-          "severity": "warning"
-        }
-      ],
-      "order/properties-alphabetical-order": [
-        true,
-        {
-          "severity": "warning"
-        }
-      ]
+      "no-unknown-animations": true,
+      "no-unknown-custom-properties": true,
+      "no-unknown-custom-media": true
     }
   },
   "dependencies": {
@@ -106,9 +90,10 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.3",
     "remark-cli": "^12.0.1",
-    "stylelint": "^17.9.0",
+    "stylelint": "^17.10.0",
+    "stylelint-config-alphabetical-order": "^2.0.0",
+    "stylelint-config-modern": "^1.0.0",
     "stylelint-config-standard": "^40.0.0",
-    "stylelint-order": "^8.1.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",
     "vite": "^8.0.10"

--- a/src/demo.css
+++ b/src/demo.css
@@ -45,7 +45,7 @@
 		font-family: system-ui;
 		font-size: 0.875rem;
 		margin: 0;
-		overscroll-behavior-y: none;
+		overscroll-behavior-block: none;
 	}
 
 	/* Inline text semantics */
@@ -77,7 +77,7 @@
 	/* Forms */
 	label {
 		color: light-dark(var(--sd-gray-60), var(--sd-gray-90));
-		display: flex;
+		display: block flex;
 		gap: 0.25rem;
 		min-block-size: 2rem;
 		padding-inline: 0.25rem;
@@ -118,7 +118,7 @@
 	stylelint-demo {
 		background-color: light-dark(var(--sd-white), var(--sd-gray-20));
 		block-size: 100dvb;
-		display: grid;
+		display: block grid;
 		grid:
 			'input-tabs' min-content
 			'inputs' 1fr
@@ -140,17 +140,17 @@
 
 	sd-input-tabs,
 	sd-output-tabs {
-		display: flex;
+		display: block flex;
 		gap: 1px;
 		inline-size: 100%;
 
-		& input[type='radio'] {
+		input[type='radio'] {
 			inline-size: 0;
 			margin: 0;
 			opacity: 0;
 		}
 
-		& label {
+		label {
 			color: light-dark(var(--sd-gray-60), var(--sd-gray-90));
 			cursor: pointer;
 			font-size: 0.75rem;
@@ -172,7 +172,7 @@
 	sd-input-tabs {
 		background-color: light-dark(var(--sd-gray-98), var(--sd-gray-20));
 
-		& label {
+		label {
 			&:has(input[type='radio']:checked) {
 				background-color: light-dark(var(--sd-white), var(--sd-gray-25));
 			}
@@ -184,7 +184,7 @@
 		border-block-start: 1px solid light-dark(var(--sd-gray-90), var(--sd-gray-25));
 		box-shadow: 0 2px 4px 0 light-dark(var(--sd-black-a-8), var(--sd-white-a-8));
 
-		& label {
+		label {
 			&:has(input[type='radio']:checked) {
 				text-decoration: underline;
 				text-underline-offset: 0.45em;
@@ -195,31 +195,31 @@
 	sd-code,
 	sd-config,
 	sd-deps {
-		display: grid;
+		display: block grid;
 		grid-template-rows: min-content 1fr;
 	}
 
 	sd-deps {
-		display: grid;
+		display: block grid;
 		grid:
 			'deps-label deps-label' min-content
 			'deps-monaco deps-installed' 1fr
 			/ 1fr 1fr;
 
-		& label {
+		label {
 			grid-area: deps-label;
 		}
 
-		& sd-deps-monaco {
+		sd-deps-monaco {
 			grid-area: deps-monaco;
 		}
 
-		& sd-deps-installed {
+		sd-deps-installed {
 			grid-area: deps-installed;
 			padding-inline: 0.5rem;
 		}
 
-		& ul {
+		ul {
 			list-style: none;
 			margin-block: unset;
 			padding-inline-start: unset;
@@ -227,22 +227,22 @@
 	}
 
 	sd-outputs {
-		display: block;
+		display: block flow;
 		grid-area: outputs;
 	}
 
 	sd-xterm-wrapper {
 		block-size: 100%;
-		display: block;
+		display: block flow;
 		line-height: 1;
 		overflow: hidden;
 		position: relative;
 
-		& * {
+		* {
 			line-height: normal;
 		}
 
-		& .xterm .xterm-viewport {
+		.xterm .xterm-viewport {
 			background-color: light-dark(var(--sd-white), var(--sd-gray-20)) !important;
 		}
 	}
@@ -250,7 +250,7 @@
 	sd-warnings,
 	sd-console {
 		block-size: 100%;
-		display: block;
+		display: block flow;
 		font-family: monospace;
 		font-size: 0.75rem;
 		inline-size: 100%;
@@ -263,7 +263,7 @@
 		container: warnings / inline-size;
 
 		ul {
-			display: grid;
+			display: block grid;
 			gap: 0.5rem 1rem;
 			list-style: none;
 			margin-block: unset;
@@ -277,18 +277,18 @@
 				}
 			}
 
-			& li {
-				display: grid;
+			li {
+				display: block grid;
 				grid-column: 1 / -1;
 				grid-template-columns: subgrid;
 				place-items: start;
 
-				& span:first-child {
-					color: gray;
+				span:first-child {
+					color: var(--sd-gray-60);
 					cursor: pointer;
 				}
 
-				& span[data-sd-severity] {
+				span[data-sd-severity] {
 					color: var(--sd-white);
 					flex-basis: 8ch;
 					font-size: 0.6875rem;
@@ -296,15 +296,15 @@
 					text-transform: uppercase;
 				}
 
-				& span[data-sd-severity='error'] {
+				span[data-sd-severity='error'] {
 					background-color: var(--sd-red);
 				}
 
-				& span[data-sd-severity='warning'] {
+				span[data-sd-severity='warning'] {
 					background-color: var(--sd-yellow);
 				}
 
-				& span:nth-child(2) {
+				span:nth-child(2) {
 					padding-inline: 0.25rem;
 				}
 			}
@@ -318,7 +318,7 @@
 
 	sd-toolbar {
 		background-color: light-dark(var(--sd-gray-98), var(--sd-gray-25));
-		display: flex;
+		display: block flex;
 		gap: 1rem;
 		grid-area: toolbar;
 		padding-block: 0.5rem;

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
 #app {
 	block-size: 100dvb;
-	display: grid;
+	display: block grid;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

This is the config I had in mind when I modernised the demo's CSS in:
- https://github.com/stylelint/stylelint-demo/pull/413

As such, the change to config didn't flag much, mainly:
- 11 `display-notation` problems
- 16 `relative-selector-nesting-notation` problems

It also caught a rogue named colour, which I've replaced with an appropriate custom property.

It's an opportunity to dogfood our new rules.