### PR TITLE
Harden `npm install` security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
+allow-git = "none"
 engine-strict=true
+ignore-scripts = true
+min-release-age = 3 # days


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Same as stylelint/stylelint-config-standard#413

> Is there anything in the PR that needs further explanation?

Add three flags to `.npmrc` to reduce supply-chain risk:

- `allow-git = "none"` — block git URL dependencies.
- `ignore-scripts = true` — skip lifecycle scripts on install.
- `min-release-age = 3` — only install package versions at least 3 days old.

Note: contributors must run `npm run prepare` manually post-clone to set the local git hooks path, since `ignore-scripts` skips the `prepare` script.

Ref: https://github.com/lirantal/npm-security-best-practices/blob/a98aeb7197d3820686337f28ea96ffe94333457b/README.md

