### PR TITLE
Shorten dev dependencies group name for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     labels:
       - 'pr: dependencies'
     groups:
-      development-dependencies:
-        dependency-type: 'development'
+      dev-deps:
+        dependency-type: development
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Like stylelint/stylelint.io#535

> Is there anything in the PR that needs further explanation?

The other repos use the `dev-deps` group name. See also:
https://github.com/search?q=org%3Astylelint+%22dev-deps%22+path%3A.github%2Fdependabot.*+NOT+is%3Aarchived&type=code
